### PR TITLE
Add static icon packs

### DIFF
--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,5 +1,6 @@
 mod controls;
 mod formatted_log;
+mod icons;
 mod lazy_paragraph;
 mod raw_log;
 mod root;
@@ -8,6 +9,7 @@ mod state;
 
 pub use controls::*;
 pub use formatted_log::*;
+pub use icons::*;
 pub use lazy_paragraph::*;
 pub use raw_log::*;
 pub use root::*;

--- a/src/widgets/formatted_log.rs
+++ b/src/widgets/formatted_log.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::{Level, Message},
     events::AppEvent,
     log::Log,
-    widgets::{BindingDisplay, LazyParagraph, LazyParagraphState, State, WithLog},
+    widgets::{BindingDisplay, IconPack, LazyParagraph, LazyParagraphState, State, WithLog},
 };
 use crossterm::event::{Event, KeyCode};
 use indexmap::IndexMap;
@@ -287,7 +287,7 @@ impl<'i> State for FormattedLogState<'i> {
         }
     }
 
-    fn add_controls(&self, controls: &mut IndexMap<BindingDisplay, &'static str>) {
+    fn add_controls<I: IconPack>(&self, controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
         match self.filters_list_state.as_ref() {
             None => {
                 controls.insert(BindingDisplay::simple_key(KeyCode::Char('f')), "Filters");
@@ -591,8 +591,8 @@ impl State for FiltersListState {
         }
     }
 
-    fn add_controls(&self, controls: &mut IndexMap<BindingDisplay, &'static str>) {
-        controls.insert(BindingDisplay::Custom(BindingDisplay::LEFT_RIGHT), "Nav");
+    fn add_controls<I: IconPack>(&self, controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
+        controls.insert(BindingDisplay::Custom(I::LEFT_RIGHT), "Nav");
     }
 }
 

--- a/src/widgets/icons.rs
+++ b/src/widgets/icons.rs
@@ -1,0 +1,101 @@
+use std::{fmt::Debug, hash::Hash};
+
+pub trait IconPack: Clone + Copy + PartialEq + Eq + Debug + Hash + Default + 'static {
+    const CONTROL_ICON: &'static str;
+    const ALT_ICON: &'static str;
+    const SHIFT_ICON: &'static str;
+
+    const LEFT_ICON: &'static str;
+    const RIGHT_ICON: &'static str;
+    const UP_ICON: &'static str;
+    const DOWN_ICON: &'static str;
+    const INSERT_ICON: &'static str;
+    const NULL_ICON: &'static str;
+    const BACKSPACE_ICON: &'static str;
+    const ENTER_ICON: &'static str;
+    const HOME_ICON: &'static str;
+    const END_ICON: &'static str;
+    const PAGEUP_ICON: &'static str;
+    const PAGEDOWN_ICON: &'static str;
+    const TAB_ICON: &'static str;
+    const BACKTAB_ICON: &'static str;
+    const DELETE_ICON: &'static str;
+    const ESC_ICON: &'static str;
+    const SPACE_ICON: &'static str;
+
+    const UP_DOWN: &'static str;
+    const LEFT_RIGHT: &'static str;
+    const ARROWS: &'static str;
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Default)]
+pub struct UnicodeIconPack;
+
+impl IconPack for UnicodeIconPack {
+    const CONTROL_ICON: &'static str = if cfg!(target_os = "macos") {
+        "\u{2318}"
+    } else {
+        "\u{2303}"
+    };
+    const ALT_ICON: &'static str = "\u{2325}";
+    const SHIFT_ICON: &'static str = "\u{21e7}";
+
+    const LEFT_ICON: &'static str = "\u{2190}";
+    const RIGHT_ICON: &'static str = "\u{2192}";
+    const UP_ICON: &'static str = "\u{2191}";
+    const DOWN_ICON: &'static str = "\u{2193}";
+    const INSERT_ICON: &'static str = "INS";
+    const NULL_ICON: &'static str = "NUL";
+    const BACKSPACE_ICON: &'static str = "\u{232b}";
+    const ENTER_ICON: &'static str = "\u{23ce}";
+    const HOME_ICON: &'static str = "\u{2196}";
+    const END_ICON: &'static str = "\u{2198}";
+    const PAGEUP_ICON: &'static str = "\u{21de}";
+    const PAGEDOWN_ICON: &'static str = "\u{21df}";
+    const TAB_ICON: &'static str = "\u{21e5}";
+    const BACKTAB_ICON: &'static str = "\u{21e4}";
+    const DELETE_ICON: &'static str = "\u{2326}";
+    const ESC_ICON: &'static str = "\u{238b}";
+    const SPACE_ICON: &'static str = "\u{2423}";
+
+    const UP_DOWN: &'static str = "\u{2191}\u{2193}";
+    const LEFT_RIGHT: &'static str = "\u{2192}\u{2190}";
+    const ARROWS: &'static str = "\u{2191}\u{2193}\u{2192}\u{2190}";
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Default)]
+pub struct NonUnicodeIconPack;
+
+impl IconPack for NonUnicodeIconPack {
+    const CONTROL_ICON: &'static str = "CTRL+";
+    const ALT_ICON: &'static str = "ALT+";
+    const SHIFT_ICON: &'static str = "SHFT+";
+
+    const LEFT_ICON: &'static str = UnicodeIconPack::LEFT_ICON;
+    const RIGHT_ICON: &'static str = UnicodeIconPack::RIGHT_ICON;
+    const UP_ICON: &'static str = UnicodeIconPack::UP_ICON;
+    const DOWN_ICON: &'static str = UnicodeIconPack::DOWN_ICON;
+    const INSERT_ICON: &'static str = "INS";
+    const NULL_ICON: &'static str = "NUL";
+    const BACKSPACE_ICON: &'static str = "BKSP";
+    const ENTER_ICON: &'static str = "ENTR";
+    const HOME_ICON: &'static str = "HOME";
+    const END_ICON: &'static str = "END";
+    const PAGEUP_ICON: &'static str = "PGUP";
+    const PAGEDOWN_ICON: &'static str = "PGDN";
+    const TAB_ICON: &'static str = "TAB";
+    const BACKTAB_ICON: &'static str = "BTAB";
+    const DELETE_ICON: &'static str = "DEL";
+    const ESC_ICON: &'static str = "ESC";
+    const SPACE_ICON: &'static str = "SPC";
+
+    const UP_DOWN: &'static str = UnicodeIconPack::UP_DOWN;
+    const LEFT_RIGHT: &'static str = UnicodeIconPack::LEFT_RIGHT;
+    const ARROWS: &'static str = UnicodeIconPack::ARROWS;
+}
+
+#[cfg(not(target_os = "windows"))]
+pub type DefaultIconPack = UnicodeIconPack;
+
+#[cfg(target_os = "windows")]
+pub type DefaultIconPack = NonUnicodeIconPack;

--- a/src/widgets/lazy_paragraph.rs
+++ b/src/widgets/lazy_paragraph.rs
@@ -1,6 +1,6 @@
 use crate::{
     events::AppEvent,
-    widgets::{BindingDisplay, Scrollbar, State},
+    widgets::{BindingDisplay, IconPack, Scrollbar, State},
 };
 use crossterm::event::{Event, KeyCode};
 use indexmap::IndexMap;
@@ -238,8 +238,8 @@ impl State for LazyParagraphState {
         }
     }
 
-    fn add_controls(&self, controls: &mut IndexMap<BindingDisplay, &'static str>) {
-        controls.insert(BindingDisplay::Custom(BindingDisplay::ARROWS), "Nav");
+    fn add_controls<I: IconPack>(&self, controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
+        controls.insert(BindingDisplay::Custom(I::ARROWS), "Nav");
         controls.insert(BindingDisplay::simple_key(KeyCode::PageUp), "Up 10");
         controls.insert(BindingDisplay::simple_key(KeyCode::PageDown), "Down 10");
         controls.insert(BindingDisplay::simple_key(KeyCode::Home), "Top");

--- a/src/widgets/raw_log.rs
+++ b/src/widgets/raw_log.rs
@@ -1,7 +1,7 @@
 use crate::{
     events::AppEvent,
     log::Log,
-    widgets::{BindingDisplay, LazyParagraph, LazyParagraphState, State, WithLog},
+    widgets::{BindingDisplay, IconPack, LazyParagraph, LazyParagraphState, State, WithLog},
 };
 use indexmap::IndexMap;
 use std::marker::PhantomData;
@@ -67,7 +67,7 @@ impl<'i> State for RawLogState<'i> {
         self.paragraph_state.update(event)
     }
 
-    fn add_controls(&self, controls: &mut IndexMap<BindingDisplay, &'static str>) {
+    fn add_controls<I: IconPack>(&self, controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
         self.paragraph_state.add_controls(controls);
     }
 }

--- a/src/widgets/root.rs
+++ b/src/widgets/root.rs
@@ -2,7 +2,7 @@ use crate::{
     events::AppEvent,
     log::Log,
     widgets::{
-        BindingDisplay, Controls, ControlsState, FormattedLog, FormattedLogState, RawLog,
+        BindingDisplay, Controls, ControlsState, FormattedLog, FormattedLogState, IconPack, RawLog,
         RawLogState, State, WithLog,
     },
 };
@@ -124,7 +124,7 @@ impl<'i> State for RootState<'i> {
         }
     }
 
-    fn add_controls(&self, controls: &mut IndexMap<BindingDisplay, &'static str>) {
+    fn add_controls<I: IconPack>(&self, controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
         // Root controls
         controls.insert(
             BindingDisplay::key(KeyCode::Char('c'), KeyModifiers::CONTROL),

--- a/src/widgets/state.rs
+++ b/src/widgets/state.rs
@@ -1,9 +1,14 @@
-use crate::{events::AppEvent, log::Log, widgets::BindingDisplay};
+use crate::{
+    events::AppEvent,
+    log::Log,
+    widgets::{BindingDisplay, IconPack},
+};
 use indexmap::IndexMap;
 
 pub trait State {
     fn update(&mut self, event: &AppEvent) -> bool;
-    fn add_controls(&self, _controls: &mut IndexMap<BindingDisplay, &'static str>) {}
+    fn add_controls<I: IconPack>(&self, _controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
+    }
 }
 
 impl State for () {


### PR DESCRIPTION
Adds static icon packs as a generic argument to `BindingDisplay`. This is used to swap between icons for terminals that support most unicode characters and ones that do not support them at compile time (by checking `target_os`). Later on, this will be extended to support swapping at runtime instead.

Closes #5