### PR TITLE
Fix tag name in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         id: get_version
         run: |
           TAG_VERSION="${GITHUB_REF/refs\/tags\//}"
-          echo ::set-output name=version::${OVERRIDE_VERSION:-TAG_VERSION}
+          echo ::set-output name=version::${OVERRIDE_VERSION:-$TAG_VERSION}
       - name: Create release
         id: release
         uses: actions/create-release@v1


### PR DESCRIPTION
Again, attempt to fix the release pipeline. This can skip all checks.