### PR TITLE
Add auto-scroll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "pufferwatch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pufferwatch"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = """
 A CLI application for filtering and monitoring SMAPI logs.

--- a/src/widgets/formatted_log.rs
+++ b/src/widgets/formatted_log.rs
@@ -209,7 +209,9 @@ impl<'i> FormattedLogState<'i> {
         trace!(lines=%self.lines.len(), max_source_width=%self.source_width, "Applied filter to formatted log");
 
         // TODO: set the offset to the line closest to the current line's offset
+        let auto_scroll = self.paragraph_state.auto_scroll;
         self.paragraph_state = LazyParagraphState::new(self.lines.len(), true);
+        self.paragraph_state.auto_scroll = auto_scroll;
     }
 
     fn format_lines(log: &'i Log, filters: LogFilters<'i>) -> (Vec<FormattedLine<'i>>, usize) {

--- a/src/widgets/formatted_log.rs
+++ b/src/widgets/formatted_log.rs
@@ -186,7 +186,7 @@ impl<'i> FormattedLogState<'i> {
                 .collect(),
         };
         let (lines, source_width) = Self::format_lines(log, filters.clone());
-        let paragraph_state = LazyParagraphState::new(lines.len());
+        let paragraph_state = LazyParagraphState::new(lines.len(), true);
         Self {
             log,
             lines,
@@ -209,7 +209,7 @@ impl<'i> FormattedLogState<'i> {
         trace!(lines=%self.lines.len(), max_source_width=%self.source_width, "Applied filter to formatted log");
 
         // TODO: set the offset to the line closest to the current line's offset
-        self.paragraph_state = LazyParagraphState::new(self.lines.len());
+        self.paragraph_state = LazyParagraphState::new(self.lines.len(), true);
     }
 
     fn format_lines(log: &'i Log, filters: LogFilters<'i>) -> (Vec<FormattedLine<'i>>, usize) {
@@ -309,8 +309,9 @@ impl<'i, 'j> WithLog<'j> for FormattedLogState<'i> {
     fn with_log(self, log: &'j Log) -> Self::Result {
         let filters = self.filters.with_log(log);
         let (lines, source_width) = FormattedLogState::format_lines(log, filters.clone());
-        let mut paragraph_state = LazyParagraphState::new(lines.len());
+        let mut paragraph_state = LazyParagraphState::new(lines.len(), true);
         paragraph_state.offset = self.paragraph_state.offset;
+        paragraph_state.auto_scroll = self.paragraph_state.auto_scroll;
         FormattedLogState {
             log,
             filters,
@@ -605,23 +606,10 @@ impl<'j> WithLog<'j> for FiltersListState {
                 selected: self.selected,
                 source: FiltersListSource::Levels,
             },
-            FiltersListSource::Sources => {
-                // let mut new_sources = log.sources().into_iter().collect_vec();
-                // new_sources.sort();
-                // let new_selected = if let Some(selected_source) = sources.get(self.selected) {
-                //     new_sources
-                //         .iter()
-                //         .position(|source| source == selected_source)
-                //         .unwrap_or(self.selected)
-                //         .min(new_sources.len().saturating_sub(1))
-                // } else {
-                //     0
-                // };
-                FiltersListState {
-                    selected: self.selected,
-                    source: FiltersListSource::Sources,
-                }
-            }
+            FiltersListSource::Sources => FiltersListState {
+                selected: self.selected,
+                source: FiltersListSource::Sources,
+            },
         }
     }
 }

--- a/src/widgets/lazy_paragraph.rs
+++ b/src/widgets/lazy_paragraph.rs
@@ -298,9 +298,9 @@ impl AutoScroll {
         }
     }
 
-    pub fn is_scrolling(&self) -> bool {
+    pub fn is_scrolling(self) -> bool {
         if let AutoScroll::Enabled { scrolling } = self {
-            *scrolling
+            scrolling
         } else {
             false
         }

--- a/src/widgets/raw_log.rs
+++ b/src/widgets/raw_log.rs
@@ -49,7 +49,7 @@ pub struct RawLogState<'i> {
 impl<'i> RawLogState<'i> {
     pub fn new(log: &'i Log) -> Self {
         let lines: Vec<_> = log.raw().lines().collect();
-        let paragraph_state = LazyParagraphState::new(lines.len());
+        let paragraph_state = LazyParagraphState::new(lines.len(), true);
         RawLogState {
             lines,
             paragraph_state,
@@ -80,7 +80,8 @@ impl<'i, 'j> WithLog<'j> for RawLogState<'i> {
             selected: self.selected,
             paragraph_state: LazyParagraphState {
                 offset: self.paragraph_state.offset,
-                ..LazyParagraphState::new(log.raw().lines().count())
+                auto_scroll: self.paragraph_state.auto_scroll,
+                ..LazyParagraphState::new(log.raw().lines().count(), true)
             },
             ..RawLogState::new(log)
         }

--- a/src/widgets/root.rs
+++ b/src/widgets/root.rs
@@ -100,7 +100,8 @@ impl<'i> RootState<'i> {
 impl<'i> State for RootState<'i> {
     fn update(&mut self, event: &AppEvent) -> bool {
         // TODO: mouse events
-        let handled = match event {
+        // Update root state
+        let mut handled = match event {
             AppEvent::TermEvent(Event::Key(key_event)) => match key_event.code {
                 KeyCode::Tab => {
                     match self.selected_widget {
@@ -114,14 +115,20 @@ impl<'i> State for RootState<'i> {
             _ => false,
         };
 
-        if handled {
-            true
-        } else {
-            match self.selected_widget {
+        // Update selected widget
+        if !handled {
+            handled = match self.selected_widget {
                 SelectedWidget::FormattedLog => self.formatted_log_state.update(event),
                 SelectedWidget::RawLog => self.raw_log_state.update(event),
-            }
+            };
         }
+
+        // Update controls state
+        if !handled {
+            handled = self.controls_state.update(event);
+        }
+
+        handled
     }
 
     fn add_controls<I: IconPack>(&self, controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {

--- a/src/widgets/state.rs
+++ b/src/widgets/state.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 
 pub trait State {
     fn update(&mut self, event: &AppEvent) -> bool;
-    
+
     fn add_controls<I: IconPack>(&self, _controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
     }
 }

--- a/src/widgets/state.rs
+++ b/src/widgets/state.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 
 pub trait State {
     fn update(&mut self, event: &AppEvent) -> bool;
+    
     fn add_controls<I: IconPack>(&self, _controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
     }
 }


### PR DESCRIPTION
Adds auto-scroll functionality to the log viewers. When the log viewer is at the bottom of the log (regardless of if it's filtered or not), then it continues to follow any new content that is appended to the log afterwards. For example, if the log file is 200 lines long and the bottom of the file is visible, then any new lines added to the file will cause the log viewer to scroll down automatically.