### PR TITLE
Add support for reading from stdin

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,26 +1,26 @@
 use crate::ast::{Level, Message, Timestamp};
+use anyhow::Context;
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_till, take_till1},
     character::complete::{digit1, space0, space1},
-    combinator::{complete, map, map_opt, map_res},
+    combinator::{complete, map, map_res},
     error::{FromExternalError, ParseError},
     multi::fold_many0,
     sequence::{delimited, preceded, separated_pair, terminated, tuple},
     IResult,
 };
-use std::num::ParseIntError;
 
 pub fn parse_message<'i, E>(i: &'i str) -> IResult<&'i str, Message<'i>, E>
 where
-    E: ParseError<&'i str> + FromExternalError<&'i str, ParseIntError>,
+    E: ParseError<&'i str> + FromExternalError<&'i str, anyhow::Error>,
 {
     let ts = map_res(
         tuple((digit1, tag(":"), digit1, tag(":"), digit1)),
         |(hh, _, mm, _, ss): (&str, &str, &str, &str, &str)| {
-            let hour = hh.parse()?;
-            let minute = mm.parse()?;
-            let second = ss.parse()?;
+            let hour = hh.parse().context("invalid hour")?;
+            let minute = mm.parse().context("invalid minute")?;
+            let second = ss.parse().context("invalid second")?;
             Ok(Timestamp {
                 hour,
                 minute,
@@ -63,7 +63,7 @@ where
 
 pub fn parse_log<'i, E>(i: &'i str) -> IResult<&'i str, Vec<Message<'i>>, E>
 where
-    E: ParseError<&'i str> + FromExternalError<&'i str, ParseIntError>,
+    E: ParseError<&'i str> + FromExternalError<&'i str, anyhow::Error>,
 {
     enum ParsedLine<'i> {
         Start(Message<'i>),
@@ -76,33 +76,33 @@ where
     ));
     let parse_log = fold_many0(
         terminated(parse_line_or_continuation, tag("\n")),
-        || Some(Vec::new()),
+        || Ok(Vec::new()),
         |acc, cur| {
             let mut acc = acc?;
             match cur {
                 ParsedLine::Start(message) => {
                     acc.push(message);
-                    Some(acc)
+                    Ok(acc)
                 }
                 ParsedLine::Continued(continued_contents) => {
-                    let mut last = acc.pop()?;
+                    let mut last = acc.pop().context("no message to continue")?;
                     let mut contents = last.contents.into_owned();
                     contents.push('\n');
                     contents.push_str(continued_contents);
                     last.contents = contents.into();
                     acc.push(last);
-                    Some(acc)
+                    Ok(acc)
                 }
             }
         },
     );
 
-    map_opt(parse_log, |messages| messages)(i)
+    map_res(parse_log, |messages| messages)(i)
 }
 
 pub fn parse_log_complete<'i, E>(i: &'i str) -> IResult<&'i str, Vec<Message<'i>>, E>
 where
-    E: ParseError<&'i str> + FromExternalError<&'i str, ParseIntError>,
+    E: ParseError<&'i str> + FromExternalError<&'i str, anyhow::Error>,
 {
     complete(parse_log)(i)
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -102,7 +102,7 @@ impl LogSource for StdinLogSource {
             .stdin
             .fill_buf()
             .ok()
-            .filter(|buf| buf.len() > 0)
+            .filter(|buf| !buf.is_empty())
             .is_none();
         if bytes_available {
             // No changes
@@ -111,7 +111,9 @@ impl LogSource for StdinLogSource {
 
         // Append to the log file
         let mut raw = log.raw().to_string();
-        let _ = self.stdin.read_to_string(&mut raw);
+        self.stdin
+            .read_to_string(&mut raw)
+            .context("error reading from stdin")?;
         Log::parse(raw).context("error parsing log").map(Some)
     }
 }


### PR DESCRIPTION
Adds a `--stdin` flag for reading from stdin. However, there are some limitations:

- In powershell, the `|` operator waits for the previous command to finish before sending the *entire* output all at once to the next command.
- In cmd, the `<` operator doesn't seem to open SDV (`pufferwatch --stdin < StardewModdingApi.exe`).
- `cat log.txt | pufferwatch --stdin` works as expected
