### PR TITLE
Add --execute option

### DIFF
--- a/src/encoded_writer.rs
+++ b/src/encoded_writer.rs
@@ -1,0 +1,49 @@
+use std::io::Write;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum ByteOrder {
+    BigEndian,
+    LittleEndian,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+pub enum EncodedWriter<W> {
+    Utf8 { writer: W },
+    Utf16 { writer: W, byte_order: ByteOrder },
+}
+
+impl<W> EncodedWriter<W>
+where
+    W: Write,
+{
+    pub fn utf8(writer: W) -> Self {
+        EncodedWriter::Utf8 { writer }
+    }
+
+    pub fn utf16(writer: W, byte_order: ByteOrder) -> Self {
+        EncodedWriter::Utf16 { writer, byte_order }
+    }
+
+    pub fn write_all(&mut self, text: &str) -> std::io::Result<()> {
+        match self {
+            EncodedWriter::Utf8 { writer } => writer.write_all(text.as_bytes()),
+            EncodedWriter::Utf16 { writer, byte_order } => {
+                let encoded = text
+                    .encode_utf16()
+                    .flat_map(|codepoint| match byte_order {
+                        ByteOrder::BigEndian => codepoint.to_be_bytes(),
+                        ByteOrder::LittleEndian => codepoint.to_le_bytes(),
+                    })
+                    .collect::<Vec<u8>>();
+                writer.write_all(&encoded)
+            }
+        }
+    }
+
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            EncodedWriter::Utf8 { writer } => writer.flush(),
+            EncodedWriter::Utf16 { writer, .. } => writer.flush(),
+        }
+    }
+}

--- a/src/encoded_writer.rs
+++ b/src/encoded_writer.rs
@@ -42,8 +42,7 @@ where
 
     pub fn flush(&mut self) -> std::io::Result<()> {
         match self {
-            EncodedWriter::Utf8 { writer } => writer.flush(),
-            EncodedWriter::Utf16 { writer, .. } => writer.flush(),
+            EncodedWriter::Utf8 { writer } | EncodedWriter::Utf16 { writer, .. } => writer.flush(),
         }
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -18,6 +18,16 @@ pub struct Log {
 }
 
 impl Log {
+    /// Creates a new empty log.
+    pub fn empty() -> Self {
+        LogBuilder {
+            raw: String::new(),
+            messages_builder: |_| Vec::new(),
+            by_source_builder: |_| HashMap::new(),
+        }
+        .build()
+    }
+
     /// Parses a log from a string.
     pub fn parse(raw: String) -> anyhow::Result<Self> {
         // Log is self-referential because the messages borrow from the raw string

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 )]
 
 mod ast;
+mod encoded_writer;
 mod events;
 mod log;
 mod parse;

--- a/src/source.rs
+++ b/src/source.rs
@@ -143,15 +143,12 @@ impl LogSource for ReaderLogSource {
         // Append to the log
         let mut raw = log.raw().to_string();
         raw.push_str(&self.unparsed);
-        match Log::parse(raw) {
-            Ok(log) => {
-                self.unparsed.clear();
-                Ok(Some(log))
-            }
-            Err(_) => {
-                debug!(?self.unparsed, "Unable to parse");
-                Ok(None)
-            }
+        if let Ok(log) = Log::parse(raw) {
+            self.unparsed.clear();
+            Ok(Some(log))
+        } else {
+            debug!(?self.unparsed, "Unable to parse");
+            Ok(None)
         }
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,15 +1,18 @@
 use crate::log::Log;
 use anyhow::Context;
+use crossbeam::channel::Receiver;
 use hotwatch::{Event, Hotwatch};
 use std::{
     fmt::Debug,
-    io::{BufRead, BufReader, Read, Stdin},
+    io::{BufRead, BufReader, Read},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    thread::JoinHandle,
 };
+use tracing::debug;
 
 pub trait LogSource {
     fn update_log(&mut self, log: &Log) -> anyhow::Result<Option<Log>>;
@@ -91,37 +94,64 @@ impl LogSource for FollowedLogSource {
 }
 
 #[derive(Debug)]
-pub struct StdinLogSource {
-    stdin: BufReader<Stdin>,
+pub struct ReaderLogSource {
+    unparsed: String,
+    rx: Receiver<anyhow::Result<String>>,
+    _reader_thread: JoinHandle<()>,
 }
 
-impl StdinLogSource {
-    pub fn new() -> Self {
-        StdinLogSource {
-            stdin: BufReader::new(std::io::stdin()),
+impl ReaderLogSource {
+    pub fn new<R: Read + Send + 'static>(reader: R) -> Self {
+        let (tx, rx) = crossbeam::channel::unbounded::<anyhow::Result<String>>();
+        let mut reader = BufReader::new(reader);
+        let reader_thread = std::thread::spawn(move || loop {
+            let mut buffer = String::new();
+            match reader.read_line(&mut buffer) {
+                Ok(0) => continue,
+                Ok(_) => tx.send(Ok(buffer)).unwrap(),
+                Err(error) => tx.send(Err(error.into())).unwrap(),
+            }
+        });
+
+        Self {
+            unparsed: String::new(),
+            rx,
+            _reader_thread: reader_thread,
         }
+    }
+
+    pub fn from_stdin() -> Self {
+        ReaderLogSource::new(std::io::stdin())
     }
 }
 
-impl LogSource for StdinLogSource {
+impl LogSource for ReaderLogSource {
     fn update_log(&mut self, log: &Log) -> anyhow::Result<Option<Log>> {
-        // Try to read a byte from stdin
-        let bytes_available = self
-            .stdin
-            .fill_buf()
-            .ok()
-            .filter(|buf| !buf.is_empty())
-            .is_none();
-        if bytes_available {
-            // No changes
-            return Ok(None);
+        // Try to get the next line
+        let first_line = match self.rx.try_recv() {
+            Ok(line) => line?,
+            Err(_) => return Ok(None),
+        };
+        self.unparsed.push_str(&first_line);
+
+        // Append to the unparsed buffer
+        self.unparsed.push_str(&first_line);
+        while let Ok(line) = self.rx.try_recv() {
+            self.unparsed.push_str(&line?);
         }
 
-        // Append to the log file
+        // Append to the log
         let mut raw = log.raw().to_string();
-        self.stdin
-            .read_to_string(&mut raw)
-            .context("error reading from stdin")?;
-        Log::parse(raw).context("error parsing log").map(Some)
+        raw.push_str(&self.unparsed);
+        match Log::parse(raw) {
+            Ok(log) => {
+                self.unparsed.clear();
+                Ok(Some(log))
+            }
+            Err(_) => {
+                debug!(?self.unparsed, "Unable to parse");
+                Ok(None)
+            }
+        }
     }
 }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,11 +1,12 @@
 use crate::{
+    encoded_writer::{ByteOrder, EncodedWriter},
     events::{AppEvent, EventController},
     log::Log,
-    source::{FollowedLogSource, LogSource, StaticLogSource, StdinLogSource},
+    source::{FollowedLogSource, LogSource, ReaderLogSource, StaticLogSource},
     widgets::{Root, RootState, State, WithLog},
 };
 use anyhow::{bail, Context};
-use clap::{command, Arg, ArgMatches, ValueHint};
+use clap::{command, Arg, ArgMatches, PossibleValue, ValueHint};
 use crossterm::{
     event::{Event, KeyCode, KeyModifiers},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
@@ -13,7 +14,11 @@ use crossterm::{
 };
 use ouroboros::self_referencing;
 use reqwest::blocking::Client;
-use std::{io::stdout, path::PathBuf, time::Duration};
+use std::{
+    io::{stdout, Write},
+    path::PathBuf,
+    process::{Child, ChildStdin, Stdio},
+};
 use tracing::{info, trace};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 use tui::{
@@ -25,7 +30,9 @@ const LOG_ARG: &str = "log";
 const FOLLOW_ARG: &str = "follow";
 const STDIN_ARG: &str = "stdin";
 const REMOTE_ARG: &str = "remote";
-const EXEC_ARG: &str = "execute";
+const SMAPI_ARG: &str = "execute";
+const SMAPI_ARGS_ARG: &str = "execute-args";
+const SMAPI_ENCODING_ARG: &str = "encoding";
 const OUTPUT_LOG_ARG: &str = "output-log";
 
 pub fn start() -> anyhow::Result<()> {
@@ -35,10 +42,17 @@ pub fn start() -> anyhow::Result<()> {
     // Setup tracing
     setup_tracing(&matches)?;
 
+    // Spawn SMAPI if needed
+    let smapi_child = if matches.is_present(SMAPI_ARG) {
+        Some(spawn_smapi(&matches)?)
+    } else {
+        None
+    };
+
     // Setup log source
     info!("Starting SMAPI Log Parser");
     let log_path = matches.value_of(LOG_ARG);
-    let (mut source, log) = get_source(&matches, log_path)?;
+    let (source, log) = get_source(&matches, log_path)?;
 
     // Initialize TUI
     trace!("Initializing TUI");
@@ -53,9 +67,60 @@ pub fn start() -> anyhow::Result<()> {
     terminal.clear()?;
 
     // TUI event loop
+    let result = render_loop(
+        log,
+        source,
+        smapi_child
+            .and_then(|child| child.stdin)
+            .map(|stdin| create_encoded_writer(&matches, stdin)),
+        &mut terminal,
+    );
+
+    // Exit alternate screen
+    terminal.backend_mut().execute(LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    crossterm::terminal::disable_raw_mode()?;
+    result
+}
+
+fn spawn_smapi(matches: &ArgMatches) -> anyhow::Result<Child> {
+    let smapi_path = matches.value_of(SMAPI_ARG).context("missing SMAPI path")?;
+    let args = matches.values_of(SMAPI_ARGS_ARG).into_iter().flatten();
+    let mut cmd = std::process::Command::new(smapi_path);
+    let cmd = args.fold(&mut cmd, |cmd, arg| cmd.arg(arg));
+    let child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .context("error starting SMAPI")?;
+    Ok(child)
+}
+
+fn create_encoded_writer<W>(matches: &ArgMatches, writer: W) -> EncodedWriter<W>
+where
+    W: Write,
+{
+    match matches.value_of(SMAPI_ENCODING_ARG) {
+        Some("utf8") => EncodedWriter::utf8(writer),
+        Some("utf16-le") => EncodedWriter::utf16(writer, ByteOrder::LittleEndian),
+        Some("utf16-be") => EncodedWriter::utf16(writer, ByteOrder::BigEndian),
+        #[cfg(windows)]
+        None => EncodedWriter::utf16(writer, ByteOrder::LittleEndian),
+        #[cfg(not(windows))]
+        None => EncodedWriter::utf8(writer),
+        Some(encoding) => unreachable!("unexpected encoding {encoding}"),
+    }
+}
+
+fn render_loop(
+    log: Log,
+    mut source: Box<dyn LogSource>,
+    smapi_stdin: Option<EncodedWriter<ChildStdin>>,
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+) -> Result<(), anyhow::Error> {
     let mut force_redraw = true;
     let (event_rx, _event_controller) = EventController::start();
-    let mut renderer = Renderer::from(log);
+    let mut renderer = Renderer::from_log(log, smapi_stdin);
     loop {
         // Read event
         trace!("Reading event");
@@ -84,15 +149,10 @@ pub fn start() -> anyhow::Result<()> {
 
         // Draw terminal
         renderer
-            .render(&mut terminal, &event, force_redraw)
+            .render(terminal, &event, force_redraw)
             .context("error rendering frame")?;
     }
 
-    // Exit alternate screen
-    std::thread::sleep(Duration::from_secs(2));
-    terminal.backend_mut().execute(LeaveAlternateScreen)?;
-    terminal.show_cursor()?;
-    crossterm::terminal::disable_raw_mode()?;
     Ok(())
 }
 
@@ -103,8 +163,7 @@ fn get_source(
     let stdin_flag = matches.is_present(STDIN_ARG);
     let follow_flag = matches.is_present(FOLLOW_ARG);
     let remote_flag = matches.is_present(REMOTE_ARG);
-    let exec_flag = matches.is_present(EXEC_ARG);
-    let too_many_sources = [stdin_flag, follow_flag, remote_flag, exec_flag]
+    let too_many_sources = [stdin_flag, follow_flag, remote_flag]
         .into_iter()
         .filter(|&f| f)
         .skip(1)
@@ -116,12 +175,12 @@ fn get_source(
             STDIN_ARG,
             FOLLOW_ARG,
             REMOTE_ARG,
-            EXEC_ARG
+            SMAPI_ARG
         );
     }
     let (source, log): (Box<dyn LogSource>, Log) = if stdin_flag {
-        let source = StdinLogSource::new();
-        let log = Log::parse(String::new()).context("error parsing empty log")?;
+        let source = ReaderLogSource::from_stdin();
+        let log = Log::empty();
         (Box::new(source), log)
     } else if follow_flag {
         let log_path = log_path
@@ -143,8 +202,6 @@ fn get_source(
         let (source, log) =
             StaticLogSource::from_string(contents).context("error creating log source")?;
         (Box::new(source), log)
-    } else if exec_flag {
-        todo!()
     } else {
         let log_path = log_path
             .map(PathBuf::from)
@@ -193,14 +250,37 @@ fn parse_args() -> ArgMatches {
                 .short('r'),
         )
         .arg(
-            Arg::new(EXEC_ARG)
+            Arg::new(SMAPI_ARG)
                 .help("Run SMAPI and track its output. The full SMAPI command must be provided (including any arguments to it).")
-                .long(EXEC_ARG)
+                .long(SMAPI_ARG)
                 .visible_alias("exec")
                 .short('e')
                 .takes_value(true)
                 .value_name("SMAPI CMD")
-                .value_hint(ValueHint::CommandString),
+                .value_hint(ValueHint::CommandName),
+        )
+        .arg(
+            Arg::new(SMAPI_ARGS_ARG)
+                .help("The arguments to pass to the SMAPI command.")
+                .index(2)
+                .last(true)
+                .multiple_values(true)
+                .value_name("SMAPI ARGS")
+                .value_hint(ValueHint::Unknown),
+        )
+        .arg(
+            Arg::new(SMAPI_ENCODING_ARG)
+                .help("The encoding to use when sending commands to SMAPI.")
+                .long(SMAPI_ENCODING_ARG)
+                .requires(SMAPI_ARG)
+                .takes_value(true)
+                .value_name("ENCODING")
+                .possible_values([
+                    PossibleValue::new("utf8").help("UTF-8"),
+                    PossibleValue::new("utf16-le").help("UTF-16 little endian").alias("utf16"),
+                    PossibleValue::new("utf16-be").help("UTF-16 big endian"),
+                ])
+                .value_hint(ValueHint::Other),
         )
         .get_matches()
 }
@@ -261,6 +341,10 @@ struct Renderer {
 }
 
 impl Renderer {
+    pub fn from_log(log: Log, smapi_stdin: Option<EncodedWriter<ChildStdin>>) -> Self {
+        Renderer::new(log, |log| Some(RootState::new(log, smapi_stdin)))
+    }
+
     pub fn render<'t, B: Backend>(
         &mut self,
         terminal: &'t mut Terminal<B>,
@@ -284,24 +368,10 @@ impl Renderer {
         if let Some(new_log) = new_log {
             self.with_root_state_mut(|root_state| {
                 let root_state = root_state.take().context("missing root state")?;
-                Ok(RendererBuilder {
-                    log: new_log,
-                    root_state_builder: |log| Some(root_state.with_log(log)),
-                }
-                .build())
+                Ok(Renderer::new(new_log, |log| Some(root_state.with_log(log))))
             })
         } else {
             Ok(self)
         }
-    }
-}
-
-impl From<Log> for Renderer {
-    fn from(log: Log) -> Self {
-        RendererBuilder {
-            log,
-            root_state_builder: |log| Some(RootState::new(log)),
-        }
-        .build()
     }
 }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -163,6 +163,7 @@ fn get_source(
     let stdin_flag = matches.is_present(STDIN_ARG);
     let follow_flag = matches.is_present(FOLLOW_ARG);
     let remote_flag = matches.is_present(REMOTE_ARG);
+    let execute_flag = matches.is_present(SMAPI_ARG);
     let too_many_sources = [stdin_flag, follow_flag, remote_flag]
         .into_iter()
         .filter(|&f| f)
@@ -182,7 +183,7 @@ fn get_source(
         let source = ReaderLogSource::from_stdin();
         let log = Log::empty();
         (Box::new(source), log)
-    } else if follow_flag {
+    } else if follow_flag || execute_flag {
         let log_path = log_path
             .map(PathBuf::from)
             .or_else(default_log_path)
@@ -240,7 +241,7 @@ fn parse_args() -> ArgMatches {
         .arg(
             Arg::new(FOLLOW_ARG)
                 .long(FOLLOW_ARG)
-                .help("Watch the log file for changes. This is not needed with --stdin.")
+                .help("Watch the log file for changes. This is not needed with --stdin or --execute.")
                 .short('f'),
         )
         .arg(

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -167,8 +167,7 @@ fn get_source(
     let too_many_sources = [stdin_flag, follow_flag, remote_flag]
         .into_iter()
         .filter(|&f| f)
-        .skip(1)
-        .next()
+        .nth(1)
         .is_some();
     if too_many_sources {
         bail!(

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1,3 +1,4 @@
+mod command_input;
 mod controls;
 mod formatted_log;
 mod icons;
@@ -7,6 +8,7 @@ mod root;
 mod scrollbar;
 mod state;
 
+pub use command_input::*;
 pub use controls::*;
 pub use formatted_log::*;
 pub use icons::*;

--- a/src/widgets/command_input.rs
+++ b/src/widgets/command_input.rs
@@ -53,10 +53,7 @@ impl<'i> StatefulWidget for CommandInput<'i> {
             vec![
                 Span::styled(state.before_cursor(), self.style),
                 Span::styled(
-                    state
-                        .at_cursor()
-                        .map(Into::into)
-                        .unwrap_or_else(String::default),
+                    state.at_cursor().map_or_else(String::default, Into::into),
                     self.style.add_modifier(Modifier::REVERSED),
                 ),
                 Span::styled(state.after_cursor(), self.style),
@@ -108,7 +105,7 @@ impl CommandInputState {
         self.text.chars().skip(self.cursor + 1).collect()
     }
 
-    pub fn take_submitted<'s>(&'s mut self) -> impl IntoIterator<Item = String> + 's {
+    pub fn take_submitted(&mut self) -> impl IntoIterator<Item = String> + '_ {
         self.submitted.drain(..)
     }
 }
@@ -117,7 +114,7 @@ impl State for CommandInputState {
     fn update(&mut self, event: &AppEvent) -> bool {
         let event = match event {
             AppEvent::TermEvent(event) => event,
-            _ => return false,
+            AppEvent::Ping => return false,
         };
 
         match event {

--- a/src/widgets/command_input.rs
+++ b/src/widgets/command_input.rs
@@ -1,0 +1,204 @@
+use crate::{events::AppEvent, widgets::State};
+use crossterm::event::{Event, KeyCode};
+use indexmap::IndexMap;
+use tui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::Span,
+    widgets::{Block, StatefulWidget, Widget},
+};
+
+use super::{BindingDisplay, IconPack};
+
+#[derive(Clone, Default)]
+pub struct CommandInput<'i> {
+    block: Option<Block<'i>>,
+    style: Style,
+    focused: bool,
+}
+
+impl<'i> CommandInput<'i> {
+    pub fn block(mut self, block: Block<'i>) -> Self {
+        self.block = Some(block);
+        self
+    }
+
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+}
+
+impl<'i> StatefulWidget for CommandInput<'i> {
+    type State = CommandInputState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        // Render block
+        let inner_area = if let Some(block) = self.block {
+            let inner = block.inner(area);
+            block.render(area, buf);
+            inner
+        } else {
+            area
+        };
+
+        // Render input
+        let spans = if self.focused {
+            vec![
+                Span::styled(state.before_cursor(), self.style),
+                Span::styled(
+                    state
+                        .at_cursor()
+                        .map(Into::into)
+                        .unwrap_or_else(String::default),
+                    self.style.add_modifier(Modifier::REVERSED),
+                ),
+                Span::styled(state.after_cursor(), self.style),
+            ]
+        } else {
+            vec![Span::styled(&state.text, self.style)]
+        };
+        let spans = spans.into();
+        buf.set_spans(
+            inner_area.left(),
+            inner_area.top(),
+            &spans,
+            inner_area.width,
+        );
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+enum EditMode {
+    Insert,
+    Overwrite,
+}
+
+impl Default for EditMode {
+    fn default() -> Self {
+        EditMode::Insert
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CommandInputState {
+    text: String,
+    // Cursor index with respect to characters (not bytes)
+    cursor: usize,
+    submitted: Vec<String>,
+    edit_mode: EditMode,
+}
+
+impl CommandInputState {
+    fn before_cursor(&self) -> String {
+        self.text.chars().take(self.cursor).collect()
+    }
+
+    fn at_cursor(&self) -> Option<char> {
+        self.text.chars().nth(self.cursor)
+    }
+
+    fn after_cursor(&self) -> String {
+        self.text.chars().skip(self.cursor + 1).collect()
+    }
+
+    pub fn take_submitted<'s>(&'s mut self) -> impl IntoIterator<Item = String> + 's {
+        self.submitted.drain(..)
+    }
+}
+
+impl State for CommandInputState {
+    fn update(&mut self, event: &AppEvent) -> bool {
+        let event = match event {
+            AppEvent::TermEvent(event) => event,
+            _ => return false,
+        };
+
+        match event {
+            Event::Key(event) => match event.code {
+                KeyCode::Backspace if self.cursor > 0 => {
+                    let chars = self.text.chars();
+                    let before = chars.clone().take(self.cursor - 1);
+                    let after = chars.skip(self.cursor);
+                    self.text = before.chain(after).collect();
+                    self.cursor -= 1;
+                    true
+                }
+                KeyCode::Enter => {
+                    self.submitted.push(std::mem::take(&mut self.text));
+                    self.cursor = 0;
+                    true
+                }
+                KeyCode::Left if self.cursor > 0 => {
+                    self.cursor -= 1;
+                    true
+                }
+                KeyCode::Right if self.cursor < self.text.len() => {
+                    self.cursor += 1;
+                    true
+                }
+                KeyCode::Home => {
+                    self.cursor = 0;
+                    true
+                }
+                KeyCode::End => {
+                    self.cursor = self.text.len();
+                    true
+                }
+                KeyCode::Delete if self.cursor < self.text.len() => {
+                    self.text.remove(self.cursor);
+                    true
+                }
+                KeyCode::Insert => {
+                    self.edit_mode = match self.edit_mode {
+                        EditMode::Insert => EditMode::Overwrite,
+                        EditMode::Overwrite => EditMode::Insert,
+                    };
+                    true
+                }
+                KeyCode::Char(c) => {
+                    match self.edit_mode {
+                        EditMode::Insert => {
+                            let chars = self.text.chars();
+                            let before = chars.clone().take(self.cursor);
+                            let inserted = [c];
+                            let after = chars.skip(self.cursor);
+                            self.text = before.chain(inserted).chain(after).collect();
+                            self.cursor += 1;
+                        }
+                        EditMode::Overwrite => {
+                            let chars = self.text.chars();
+                            let before = chars.clone().take(self.cursor);
+                            let inserted = [c];
+                            let after = chars.skip(self.cursor + 1);
+                            self.text = before.chain(inserted).chain(after).collect();
+                            self.cursor += 1;
+                        }
+                    }
+
+                    true
+                }
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+
+    fn add_controls<I: IconPack>(&self, controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
+        controls.insert(BindingDisplay::simple_key(KeyCode::Enter), "Execute");
+        controls.insert(BindingDisplay::Custom(I::LEFT_RIGHT), "Nav");
+        controls.insert(
+            BindingDisplay::simple_key(KeyCode::Insert),
+            match self.edit_mode {
+                EditMode::Insert => "Overwrite",
+                EditMode::Overwrite => "Insert",
+            },
+        );
+    }
+}

--- a/src/widgets/icons.rs
+++ b/src/widgets/icons.rs
@@ -32,31 +32,31 @@ pub trait IconPack: Clone + Copy + PartialEq + Eq + Debug + Hash + Default + 'st
 pub struct UnicodeIconPack;
 
 impl IconPack for UnicodeIconPack {
-    const CONTROL_ICON: &'static str = "\u{2303}";
-    const ALT_ICON: &'static str = "\u{2325}";
-    const SHIFT_ICON: &'static str = "\u{21e7}";
+    const CONTROL_ICON: &'static str = "⌃";
+    const ALT_ICON: &'static str = "⌥";
+    const SHIFT_ICON: &'static str = "⇧";
 
-    const LEFT_ICON: &'static str = "\u{2190}";
-    const RIGHT_ICON: &'static str = "\u{2192}";
-    const UP_ICON: &'static str = "\u{2191}";
-    const DOWN_ICON: &'static str = "\u{2193}";
+    const LEFT_ICON: &'static str = "←";
+    const RIGHT_ICON: &'static str = "→";
+    const UP_ICON: &'static str = "↑";
+    const DOWN_ICON: &'static str = "↓";
     const INSERT_ICON: &'static str = "INS";
     const NULL_ICON: &'static str = "NUL";
-    const BACKSPACE_ICON: &'static str = "\u{232b}";
-    const ENTER_ICON: &'static str = "\u{23ce}";
-    const HOME_ICON: &'static str = "\u{2196}";
-    const END_ICON: &'static str = "\u{2198}";
-    const PAGEUP_ICON: &'static str = "\u{21de}";
-    const PAGEDOWN_ICON: &'static str = "\u{21df}";
-    const TAB_ICON: &'static str = "\u{21e5}";
-    const BACKTAB_ICON: &'static str = "\u{21e4}";
-    const DELETE_ICON: &'static str = "\u{2326}";
-    const ESC_ICON: &'static str = "\u{238b}";
-    const SPACE_ICON: &'static str = "\u{2423}";
+    const BACKSPACE_ICON: &'static str = "⌫";
+    const ENTER_ICON: &'static str = "⏎";
+    const HOME_ICON: &'static str = "↖";
+    const END_ICON: &'static str = "↘";
+    const PAGEUP_ICON: &'static str = "⇞";
+    const PAGEDOWN_ICON: &'static str = "⇟";
+    const TAB_ICON: &'static str = "⇥";
+    const BACKTAB_ICON: &'static str = "⇤";
+    const DELETE_ICON: &'static str = "⌦";
+    const ESC_ICON: &'static str = "⎋";
+    const SPACE_ICON: &'static str = "␣";
 
-    const UP_DOWN: &'static str = "\u{2191}\u{2193}";
-    const LEFT_RIGHT: &'static str = "\u{2192}\u{2190}";
-    const ARROWS: &'static str = "\u{2191}\u{2193}\u{2192}\u{2190}";
+    const UP_DOWN: &'static str = "↑↓";
+    const LEFT_RIGHT: &'static str = "→←";
+    const ARROWS: &'static str = "↑↓→←";
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Default)]

--- a/src/widgets/root.rs
+++ b/src/widgets/root.rs
@@ -34,7 +34,7 @@ impl<'i> StatefulWidget for Root<'i> {
                 let mut constraints = Vec::with_capacity(3);
                 constraints.push(Constraint::Min(0));
                 if state.command_input_state.is_some() {
-                    constraints.push(Constraint::Length(3))
+                    constraints.push(Constraint::Length(3));
                 }
                 constraints.push(Constraint::Length(1));
                 constraints
@@ -57,7 +57,9 @@ impl<'i> StatefulWidget for Root<'i> {
                 SelectedWidget::RawLog => {
                     vec![Constraint::Percentage(20), Constraint::Percentage(80)]
                 }
-                _ => vec![Constraint::Percentage(50), Constraint::Percentage(50)],
+                SelectedWidget::CommandInput => {
+                    vec![Constraint::Percentage(50), Constraint::Percentage(50)]
+                }
             })
             .split(area);
         let formatted_log_area = layout[0];
@@ -146,13 +148,17 @@ impl<'i> State for RootState<'i> {
             AppEvent::TermEvent(Event::Key(key_event)) => match key_event.code {
                 KeyCode::Tab => {
                     match self.selected_widget {
-                        SelectedWidget::FormattedLog => self.select_widget(SelectedWidget::RawLog),
-                        SelectedWidget::RawLog if self.command_input_state.is_none() => {
-                            self.select_widget(SelectedWidget::FormattedLog)
+                        SelectedWidget::FormattedLog => {
+                            self.select_widget(SelectedWidget::RawLog);
                         }
-                        SelectedWidget::RawLog => self.select_widget(SelectedWidget::CommandInput),
+                        SelectedWidget::RawLog if self.command_input_state.is_none() => {
+                            self.select_widget(SelectedWidget::FormattedLog);
+                        }
+                        SelectedWidget::RawLog => {
+                            self.select_widget(SelectedWidget::CommandInput);
+                        }
                         SelectedWidget::CommandInput => {
-                            self.select_widget(SelectedWidget::FormattedLog)
+                            self.select_widget(SelectedWidget::FormattedLog);
                         }
                     }
                     true
@@ -160,13 +166,17 @@ impl<'i> State for RootState<'i> {
                 KeyCode::BackTab => {
                     match self.selected_widget {
                         SelectedWidget::FormattedLog if self.command_input_state.is_none() => {
-                            self.select_widget(SelectedWidget::RawLog)
+                            self.select_widget(SelectedWidget::RawLog);
                         }
                         SelectedWidget::FormattedLog => {
-                            self.select_widget(SelectedWidget::CommandInput)
+                            self.select_widget(SelectedWidget::CommandInput);
                         }
-                        SelectedWidget::RawLog => self.select_widget(SelectedWidget::FormattedLog),
-                        SelectedWidget::CommandInput => self.select_widget(SelectedWidget::RawLog),
+                        SelectedWidget::RawLog => {
+                            self.select_widget(SelectedWidget::FormattedLog);
+                        }
+                        SelectedWidget::CommandInput => {
+                            self.select_widget(SelectedWidget::RawLog);
+                        }
                     }
                     true
                 }
@@ -183,8 +193,7 @@ impl<'i> State for RootState<'i> {
                 SelectedWidget::CommandInput => self
                     .command_input_state
                     .as_mut()
-                    .map(|(state, _)| state.update(event))
-                    .unwrap_or(false),
+                    .map_or(false, |(state, _)| state.update(event)),
             };
         }
 
@@ -219,7 +228,7 @@ impl<'i> State for RootState<'i> {
             SelectedWidget::RawLog => self.raw_log_state.add_controls(controls),
             SelectedWidget::CommandInput => {
                 if let Some((command_input_state, _)) = self.command_input_state.as_ref() {
-                    command_input_state.add_controls(controls)
+                    command_input_state.add_controls(controls);
                 }
             }
         }

--- a/src/widgets/state.rs
+++ b/src/widgets/state.rs
@@ -6,8 +6,10 @@ use crate::{
 use indexmap::IndexMap;
 
 pub trait State {
+    /// Updates this state. Returns `true` if the event was handled.
     fn update(&mut self, event: &AppEvent) -> bool;
 
+    /// Adds controls this state uses to the given map.
     fn add_controls<I: IconPack>(&self, _controls: &mut IndexMap<BindingDisplay<I>, &'static str>) {
     }
 }


### PR DESCRIPTION
Adds an option to execute SMAPI with `pufferwatch` and send commands to it. This mode automatically follows the selected log file (which ideally would be the log SMAPI uses by default).