### PR TITLE
Swap logs to be rendered as separate tabs

### DIFF
--- a/src/widgets/command_input.rs
+++ b/src/widgets/command_input.rs
@@ -54,10 +54,7 @@ impl<'i> StatefulWidget for CommandInput<'i> {
             vec![
                 Span::styled(state.before_cursor(), self.style),
                 Span::styled(
-                    state
-                        .at_cursor()
-                        .map(String::from)
-                        .unwrap_or_else(|| " ".into()),
+                    state.at_cursor().map_or_else(|| " ".into(), String::from),
                     self.style.add_modifier(match state.edit_mode {
                         EditMode::Insert => Modifier::UNDERLINED,
                         EditMode::Overwrite => Modifier::REVERSED,

--- a/src/widgets/command_input.rs
+++ b/src/widgets/command_input.rs
@@ -1,4 +1,7 @@
-use crate::{events::AppEvent, widgets::State};
+use crate::{
+    events::AppEvent,
+    widgets::{BindingDisplay, IconPack, State},
+};
 use crossterm::event::{Event, KeyCode};
 use indexmap::IndexMap;
 use tui::{
@@ -8,8 +11,6 @@ use tui::{
     text::Span,
     widgets::{Block, StatefulWidget, Widget},
 };
-
-use super::{BindingDisplay, IconPack};
 
 #[derive(Clone, Default)]
 pub struct CommandInput<'i> {
@@ -53,7 +54,10 @@ impl<'i> StatefulWidget for CommandInput<'i> {
             vec![
                 Span::styled(state.before_cursor(), self.style),
                 Span::styled(
-                    state.at_cursor().map_or_else(String::default, Into::into),
+                    state
+                        .at_cursor()
+                        .map(String::from)
+                        .unwrap_or_else(|| " ".into()),
                     self.style.add_modifier(Modifier::REVERSED),
                 ),
                 Span::styled(state.after_cursor(), self.style),

--- a/src/widgets/command_input.rs
+++ b/src/widgets/command_input.rs
@@ -58,7 +58,10 @@ impl<'i> StatefulWidget for CommandInput<'i> {
                         .at_cursor()
                         .map(String::from)
                         .unwrap_or_else(|| " ".into()),
-                    self.style.add_modifier(Modifier::REVERSED),
+                    self.style.add_modifier(match state.edit_mode {
+                        EditMode::Insert => Modifier::UNDERLINED,
+                        EditMode::Overwrite => Modifier::REVERSED,
+                    }),
                 ),
                 Span::styled(state.after_cursor(), self.style),
             ]

--- a/src/widgets/controls.rs
+++ b/src/widgets/controls.rs
@@ -117,7 +117,7 @@ impl StatefulWidget for Controls {
     type State = ControlsState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        if area.height <= 0 {
+        if area.height == 0 {
             return;
         }
 

--- a/src/widgets/controls.rs
+++ b/src/widgets/controls.rs
@@ -117,6 +117,10 @@ impl StatefulWidget for Controls {
     type State = ControlsState;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        if area.height <= 0 {
+            return;
+        }
+
         // Create the "More" label
         let more_label = Span::styled("More [.]", self.style);
 

--- a/src/widgets/root.rs
+++ b/src/widgets/root.rs
@@ -15,7 +15,7 @@ use tui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
-    widgets::{Block, BorderType, Borders, StatefulWidget},
+    widgets::{Block, BorderType, Borders, StatefulWidget, Tabs, Widget},
 };
 
 #[derive(Clone, Debug, Default)]
@@ -27,7 +27,11 @@ impl<'i> StatefulWidget for Root<'i> {
     type State = RootState<'i>;
 
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
-        // Get outer layout
+        // Styles
+        let active_style = Style::default().fg(Color::White).bg(Color::Black);
+        let inactive_style = active_style.fg(Color::DarkGray);
+
+        // Get vertical layout
         let mut layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints({
@@ -45,48 +49,68 @@ impl<'i> StatefulWidget for Root<'i> {
             .command_input_state
             .is_some()
             .then(|| layout.pop().unwrap());
-        let area = layout.pop().unwrap();
+        let log_area = layout.pop().unwrap();
 
-        // Get inner layout
-        let layout = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(match state.selected_widget {
-                SelectedWidget::FormattedLog => {
-                    vec![Constraint::Percentage(80), Constraint::Percentage(20)]
-                }
-                SelectedWidget::RawLog => {
-                    vec![Constraint::Percentage(20), Constraint::Percentage(80)]
-                }
-                SelectedWidget::CommandInput => {
-                    vec![Constraint::Percentage(50), Constraint::Percentage(50)]
-                }
+        // Draw tabs
+        let tabs_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(if state.selected_widget == SelectedWidget::Log {
+                active_style
+            } else {
+                inactive_style
             })
-            .split(area);
-        let formatted_log_area = layout[0];
-        let raw_log_area = layout[1];
+            .border_type(BorderType::Double);
+        let log_inner_area = tabs_block.inner(log_area);
+        Tabs::new(vec!["Log".into(), "Raw".into()])
+            .block(tabs_block)
+            .style(active_style)
+            .divider("|")
+            .highlight_style(active_style.fg(Color::Black).bg(Color::White))
+            .select(match state.selected_tab {
+                SelectedTab::FormattedLog => 0,
+                SelectedTab::RawLog => 1,
+            })
+            .render(log_area, buf);
 
-        // Draw formatted log
-        state
-            .formatted_log_state
-            .selected(state.selected_widget == SelectedWidget::FormattedLog);
-        FormattedLog::default().render(formatted_log_area, buf, &mut state.formatted_log_state);
-
-        // Draw raw log
-        state
-            .raw_log_state
-            .set_selected(state.selected_widget == SelectedWidget::RawLog);
-        RawLog::default().render(raw_log_area, buf, &mut state.raw_log_state);
+        // Draw selected tab's contents
+        let log_inner_area = Rect {
+            x: log_inner_area.x,
+            y: log_inner_area.y + 1,
+            width: log_inner_area.width,
+            height: log_inner_area.height.saturating_sub(1),
+        };
+        match state.selected_tab {
+            SelectedTab::FormattedLog => {
+                // Draw formatted log
+                FormattedLog::default()
+                    .default_style(if state.selected_widget == SelectedWidget::Log {
+                        active_style
+                    } else {
+                        inactive_style
+                    })
+                    .show_colors(state.selected_widget == SelectedWidget::Log)
+                    .render(log_inner_area, buf, &mut state.formatted_log_state);
+            }
+            SelectedTab::RawLog => {
+                // Draw raw log
+                RawLog::default()
+                    .style(if state.selected_widget == SelectedWidget::Log {
+                        active_style
+                    } else {
+                        inactive_style
+                    })
+                    .render(log_inner_area, buf, &mut state.raw_log_state);
+            }
+        }
 
         // Draw command input
         if let Some((command_input_state, _)) = state.command_input_state.as_mut() {
             let focused = state.selected_widget == SelectedWidget::CommandInput;
-            let style = Style::default()
-                .fg(if focused {
-                    Color::White
-                } else {
-                    Color::DarkGray
-                })
-                .bg(Color::Black);
+            let style = if focused {
+                active_style
+            } else {
+                inactive_style
+            };
             CommandInput::default()
                 .style(style)
                 .block(
@@ -117,26 +141,19 @@ pub struct RootState<'i> {
     command_input_state: Option<(CommandInputState, EncodedWriter<ChildStdin>)>,
     controls_state: ControlsState,
     selected_widget: SelectedWidget,
+    selected_tab: SelectedTab,
 }
 
 impl<'i> RootState<'i> {
     pub fn new(log: &'i Log, command_stdin: Option<EncodedWriter<ChildStdin>>) -> Self {
-        let mut state = Self {
+        RootState {
             raw_log_state: RawLogState::new(log),
             formatted_log_state: FormattedLogState::new(log),
             command_input_state: command_stdin.map(|stdin| (CommandInputState::default(), stdin)),
             controls_state: ControlsState::default(),
             selected_widget: SelectedWidget::default(),
-        };
-
-        // Select the selected widget to update the widget states
-        state.select_widget(state.selected_widget);
-
-        state
-    }
-
-    fn select_widget(&mut self, widget: SelectedWidget) {
-        self.selected_widget = widget;
+            selected_tab: SelectedTab::default(),
+        }
     }
 }
 
@@ -146,38 +163,26 @@ impl<'i> State for RootState<'i> {
         // Update root state
         let mut handled = match event {
             AppEvent::TermEvent(Event::Key(key_event)) => match key_event.code {
-                KeyCode::Tab => {
-                    match self.selected_widget {
-                        SelectedWidget::FormattedLog => {
-                            self.select_widget(SelectedWidget::RawLog);
-                        }
-                        SelectedWidget::RawLog if self.command_input_state.is_none() => {
-                            self.select_widget(SelectedWidget::FormattedLog);
-                        }
-                        SelectedWidget::RawLog => {
-                            self.select_widget(SelectedWidget::CommandInput);
-                        }
-                        SelectedWidget::CommandInput => {
-                            self.select_widget(SelectedWidget::FormattedLog);
-                        }
-                    }
+                KeyCode::Tab if self.selected_widget == SelectedWidget::Log => {
+                    self.selected_tab = match self.selected_tab {
+                        SelectedTab::FormattedLog => SelectedTab::RawLog,
+                        SelectedTab::RawLog => SelectedTab::FormattedLog,
+                    };
                     true
                 }
-                KeyCode::BackTab => {
-                    match self.selected_widget {
-                        SelectedWidget::FormattedLog if self.command_input_state.is_none() => {
-                            self.select_widget(SelectedWidget::RawLog);
-                        }
-                        SelectedWidget::FormattedLog => {
-                            self.select_widget(SelectedWidget::CommandInput);
-                        }
-                        SelectedWidget::RawLog => {
-                            self.select_widget(SelectedWidget::FormattedLog);
-                        }
-                        SelectedWidget::CommandInput => {
-                            self.select_widget(SelectedWidget::RawLog);
-                        }
-                    }
+                KeyCode::BackTab if self.selected_widget == SelectedWidget::Log => {
+                    self.selected_tab = match self.selected_tab {
+                        SelectedTab::FormattedLog => SelectedTab::RawLog,
+                        SelectedTab::RawLog => SelectedTab::FormattedLog,
+                    };
+                    true
+                }
+                KeyCode::Char('i') if self.selected_widget == SelectedWidget::Log => {
+                    self.selected_widget = SelectedWidget::CommandInput;
+                    true
+                }
+                KeyCode::Esc if self.selected_widget == SelectedWidget::CommandInput => {
+                    self.selected_widget = SelectedWidget::Log;
                     true
                 }
                 _ => false,
@@ -188,8 +193,10 @@ impl<'i> State for RootState<'i> {
         // Update selected widget
         if !handled {
             handled = match self.selected_widget {
-                SelectedWidget::FormattedLog => self.formatted_log_state.update(event),
-                SelectedWidget::RawLog => self.raw_log_state.update(event),
+                SelectedWidget::Log => match self.selected_tab {
+                    SelectedTab::FormattedLog => self.formatted_log_state.update(event),
+                    SelectedTab::RawLog => self.raw_log_state.update(event),
+                },
                 SelectedWidget::CommandInput => self
                     .command_input_state
                     .as_mut()
@@ -224,9 +231,20 @@ impl<'i> State for RootState<'i> {
 
         // Selected widget controls
         match self.selected_widget {
-            SelectedWidget::FormattedLog => self.formatted_log_state.add_controls(controls),
-            SelectedWidget::RawLog => self.raw_log_state.add_controls(controls),
+            SelectedWidget::Log => {
+                controls.insert(BindingDisplay::simple_key(KeyCode::Tab), "Next tab");
+                controls.insert(BindingDisplay::simple_key(KeyCode::BackTab), "Previous tab");
+                if self.command_input_state.is_some() {
+                    controls.insert(BindingDisplay::simple_key(KeyCode::Char('i')), "Command");
+                }
+
+                match self.selected_tab {
+                    SelectedTab::FormattedLog => self.formatted_log_state.add_controls(controls),
+                    SelectedTab::RawLog => self.raw_log_state.add_controls(controls),
+                }
+            }
             SelectedWidget::CommandInput => {
+                controls.insert(BindingDisplay::simple_key(KeyCode::Esc), "Back");
                 if let Some((command_input_state, _)) = self.command_input_state.as_ref() {
                     command_input_state.add_controls(controls);
                 }
@@ -245,19 +263,31 @@ impl<'i, 'j> WithLog<'j> for RootState<'i> {
             command_input_state: self.command_input_state,
             controls_state: self.controls_state,
             selected_widget: self.selected_widget,
+            selected_tab: self.selected_tab,
         }
     }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-enum SelectedWidget {
+enum SelectedTab {
     FormattedLog,
     RawLog,
+}
+
+impl Default for SelectedTab {
+    fn default() -> Self {
+        SelectedTab::FormattedLog
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+enum SelectedWidget {
+    Log,
     CommandInput,
 }
 
 impl Default for SelectedWidget {
     fn default() -> Self {
-        SelectedWidget::FormattedLog
+        SelectedWidget::Log
     }
 }


### PR DESCRIPTION
The different type of log widgets are now different tabs that can be swapped between. This increases the amount of space they have to render with.