### PR TITLE
Update to clap 4 + command-based CLI redesign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,25 +152,37 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "31c9484ccdc4cb8e7b117cbd0eb150c7c0f04464854e4679aeb50ef03b32d003"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -480,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,9 +655,9 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -703,15 +721,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -895,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "os_str_bytes"
@@ -995,16 +1013,16 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "3edcd08cf4fea98d1ae6c9ddd3b8ccb1acac7c3693d62625969a7daa04a2ae36"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pufferwatch"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1017,11 +1035,25 @@ dependencies = [
  "nom",
  "notify 5.0.0",
  "ouroboros",
+ "quick-xml",
  "reqwest",
+ "serde",
  "tracing",
  "tracing-subscriber",
  "tui",
  "unicode-width",
+ "winreg",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e21a144a0ffb5fad7b464babcdab934a325ad69b7c0373bcfef5cbd9799ca9"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1079,9 +1111,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "async-compression",
  "base64",
@@ -1096,9 +1128,9 @@ dependencies = [
  "hyper-rustls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -1188,18 +1220,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1307,9 +1339,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1326,25 +1358,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-
-[[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1377,9 +1403,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1387,7 +1413,6 @@ dependencies = [
  "memchr",
  "mio 0.8.4",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "socket2",
  "winapi 0.3.9",
@@ -1694,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.4"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
+checksum = "0a1af219c3e254a8b4649d6ddaef886b2015089f35f2ac5e1db31410c0566ab8"
 dependencies = [
  "atty",
  "bitflags",
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.1"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
+checksum = "cd114ae53ce5a0670f43d2f169c1cd26c69b4896b0c121900cf1e4d06d67316c"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.2"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9484ccdc4cb8e7b117cbd0eb150c7c0f04464854e4679aeb50ef03b32d003"
+checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
 dependencies = [
  "atty",
  "bitflags",
@@ -233,15 +233,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
@@ -257,12 +256,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell",
 ]
 
 [[package]]
@@ -721,9 +719,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "lock_api"
@@ -1013,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edcd08cf4fea98d1ae6c9ddd3b8ccb1acac7c3693d62625969a7daa04a2ae36"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,25 @@
 [package]
 name = "pufferwatch"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
-description = """
-A CLI application for filtering and monitoring SMAPI logs.
-"""
+description = "A CLI application for filtering and monitoring SMAPI logs."
 publish = false
 
 [dependencies]
 # Errors
 anyhow = "1"
+
 # Parsing
 nom = "7"
-clap = { version = "3", features = ["cargo"] }
+clap = { version = "4", features = ["derive", "cargo"] }
+serde = { version = "1", features = ["derive"] }
+quick-xml = { version = "0.25", features = ["encoding", "serialize"] }
+
 # UI
 tui = { version = "0.19", default-features = false, features = ['crossterm'] }
 crossterm = { version = "0.25", features = ["serde"] }
 unicode-width = "0.1"
+
 # Utility
 itertools = "0.10"
 crossbeam = "0.8"
@@ -25,9 +28,11 @@ dirs = "4"
 notify = "5"
 hotwatch = "0.4"
 ouroboros = "0.15"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 # Web client
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",
@@ -37,3 +42,12 @@ reqwest = { version = "0.11", default-features = false, features = [
     "deflate",
     "socks",
 ] }
+
+[target.'cfg(windows)'.dependencies]
+# Utility
+winreg = { version = "0.10" }
+
+[profile.release]
+opt-level = 3
+codegen-units = 1
+lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1"
 
 # Parsing
 nom = "7"
-clap = { version = "4", features = ["derive", "cargo"] }
+clap = { version = "4", features = ["derive", "cargo", "deprecated"] }
 serde = { version = "1", features = ["derive"] }
 quick-xml = { version = "0.25", features = ["encoding", "serialize"] }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,77 @@
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use reqwest::Url;
+use std::{ffi::OsString, path::PathBuf};
+
+/// A CLI application for filtering and monitoring SMAPI logs.
+#[derive(Clone, Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct App {
+    /// The command to execute.
+    #[command(subcommand)]
+    pub command: AppCommand,
+    /// The path to output this application's logs to (not SMAPI logs). Set
+    /// the RUST_LOG environment variable to configure the output.
+    #[arg(long)]
+    pub output_log: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug, Subcommand)]
+pub enum AppCommand {
+    /// Read from a local log file.
+    Log(LogCommand),
+    /// Read from stdin.
+    Stdin(StdinCommand),
+    /// Read from a remote log file.
+    Remote(RemoteCommand),
+    /// Run SMAPI and monitor the logs.
+    Run(RunCommand),
+}
+
+#[derive(Clone, Debug, Args)]
+pub struct LogCommand {
+    // The path to the log file.
+    #[arg(short, long)]
+    pub log: Option<PathBuf>,
+    /// Watch the log file for changes. This is enabled when executing a command.
+    #[arg(short, long)]
+    pub follow: bool,
+}
+
+/// Read the log from stdin.
+#[derive(Clone, Debug, Args)]
+pub struct StdinCommand;
+
+/// Download the log from a remote source.
+#[derive(Clone, Debug, Args)]
+pub struct RemoteCommand {
+    /// The URL of the log file.
+    pub url: Url,
+}
+
+/// Run SMAPI and watches the output.
+#[derive(Clone, Debug, Args)]
+pub struct RunCommand {
+    /// The path to the SMAPI executable.
+    pub smapi_path: Option<PathBuf>,
+    /// The arguments to pass to SMAPI.
+    pub smapi_args: Vec<OsString>,
+    // The path to the log file.
+    #[arg(short, long)]
+    pub log: Option<PathBuf>,
+    /// The encoding to use when sending commmands to SMAPI.
+    #[arg(long, value_enum)]
+    #[cfg_attr(windows, arg(default_value_t = CommandEncoding::Utf16Be))]
+    #[cfg_attr(not(windows), arg(default_value_t = CommandEncoding::Utf8))]
+    pub encoding: CommandEncoding,
+}
+
+/// The encoding to use when sending commands.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, ValueEnum)]
+pub enum CommandEncoding {
+    /// UTF-8 encoding.
+    Utf8,
+    /// UTF-16 (little endian) encoding.
+    Utf16Le,
+    /// UTF-16 (big endian) encoding.
+    Utf16Be,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,7 @@ pub struct RunCommand {
     /// The path to the SMAPI executable.
     pub smapi_path: Option<PathBuf>,
     /// The arguments to pass to SMAPI.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub smapi_args: Vec<OsString>,
     // The path to the log file.
     #[arg(short, long)]

--- a/src/install_path.rs
+++ b/src/install_path.rs
@@ -18,6 +18,7 @@ struct PropertyGroup {
     pub game_path: PathBuf,
 }
 
+/// Gets the possible installation paths for Stardew Valley.
 #[instrument(level = "trace")]
 pub fn get_install_paths() -> impl IntoIterator<Item = PathBuf> {
     let home = dirs::home_dir();

--- a/src/install_path.rs
+++ b/src/install_path.rs
@@ -40,6 +40,7 @@ fn get_custom_install_path(home: &Path) -> Option<PathBuf> {
     Some(targets.property_group.game_path)
 }
 
+#[allow(clippy::used_underscore_binding)]
 fn get_default_install_paths(_home: Option<&Path>) -> impl IntoIterator<Item = PathBuf> + 'static {
     #[cfg(unix)]
     fn unix_paths(home: Option<&Path>) -> impl IntoIterator<Item = PathBuf> + 'static {

--- a/src/install_path.rs
+++ b/src/install_path.rs
@@ -1,0 +1,144 @@
+use serde::Deserialize;
+use std::{
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+use tracing::{instrument, trace};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct TargetsFile {
+    pub property_group: PropertyGroup,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct PropertyGroup {
+    pub game_path: PathBuf,
+}
+
+#[instrument(level = "trace")]
+pub fn get_install_paths() -> impl IntoIterator<Item = PathBuf> {
+    let home = dirs::home_dir();
+    let custom_paths = home
+        .as_ref()
+        .and_then(|home| get_custom_install_path(&home));
+    let default_paths = get_default_install_paths(home.as_ref().map(AsRef::as_ref));
+    custom_paths
+        .into_iter()
+        .chain(default_paths)
+        .flat_map(|path| path.canonicalize().ok())
+        .inspect(|path| trace!(?path, "possible SDV path"))
+        .filter(|path| looks_like_game_folder(&path))
+        .inspect(|path| trace!(?path, "SDV path verified"))
+}
+
+fn looks_like_game_folder(_dir: &Path) -> bool {
+    // TODO
+    true
+}
+
+fn get_custom_install_path(home: &Path) -> Option<PathBuf> {
+    let targets_file = home.join("stardewvalley.targets");
+    let targets_file = File::open(targets_file).ok()?;
+    let targets: TargetsFile = quick_xml::de::from_reader(BufReader::new(targets_file)).ok()?;
+    Some(targets.property_group.game_path)
+}
+
+fn get_default_install_paths(_home: Option<&Path>) -> impl IntoIterator<Item = PathBuf> + 'static {
+    #[cfg(unix)]
+    fn unix_paths(home: Option<&Path>) -> impl IntoIterator<Item = PathBuf> + 'static {
+        home.map(|dir| {
+            [
+                dir.join("GOG Games/Stardew Valley/game"),
+                dir.join(".steam/steam/steamapps/common/Stardew Valley"),
+                dir.join(".local/share/Steam/steamapps/common/Stardew Valley"),
+            ]
+        })
+        .into_iter()
+        .flatten()
+    }
+
+    #[cfg(target_os = "macos")]
+    fn mac_paths(home: Option<&Path>) -> impl IntoIterator<Item = PathBuf> + 'static {
+        std::iter::once(PathBuf::from(
+            "/Applications/Stardew Valley.app/Contents/MacOS",
+        ))
+        .chain(home.map(|dir| {
+            dir.join(
+                "/Library/Application Support/Steam/steamapps/common/Stardew Valley/Contents/MacOS",
+            )
+        }))
+    }
+
+    #[cfg(windows)]
+    fn windows_paths() -> impl IntoIterator<Item = PathBuf> {
+        use std::ffi::OsString;
+        use winreg::{
+            enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE},
+            RegKey,
+        };
+
+        // Collect paths
+        let paths = std::iter::empty();
+
+        // Get relevant registry values
+        let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let paths = paths.chain(
+            hklm.open_subkey(
+                r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 413150",
+            )
+            .and_then(|key| key.get_value("InstallLocation"))
+            .map(OsString::into),
+        );
+        let paths = paths.chain(
+            hklm.open_subkey(r"SOFTWARE\WOW6432Node\GOG.com\Games\1453375253")
+                .and_then(|key| key.get_value("PATH"))
+                .map(OsString::into),
+        );
+        let paths = paths.chain(
+            hkcu.open_subkey(r"SOFTWARE\Valve\Steam")
+                .and_then(|key| key.get_value("SteamPath"))
+                .map(|path: OsString| Path::new(&path).join(r"steamapps\common\Stardew Valley")),
+        );
+
+        // Default GOG/Steam paths
+        let paths = paths.chain(
+            [
+                Path::new(r"C:\Program Files"),
+                Path::new(r"C:\Program Files (x86)"),
+            ]
+            .into_iter()
+            .flat_map(|program_files| {
+                [
+                    program_files.join(r"GalaxyClient\Games\Stardew Valley"),
+                    program_files.join(r"GOG Galaxy\Games\Stardew Valley"),
+                    program_files.join(r"GOG Games\Stardew Valley"),
+                    program_files.join(r"Steam\steamapps\common\Stardew Valley"),
+                ]
+            }),
+        );
+
+        // Xbox paths
+        let paths = paths.chain(('C'..='H').into_iter().map(|drive| {
+            PathBuf::from(format!(
+                r"{drive}:\Program Files\ModifiableWindowsApps\Stardew Valley"
+            ))
+        }));
+
+        paths
+    }
+
+    // Collect paths
+    let paths = std::iter::empty();
+    #[cfg(unix)]
+    let paths = paths.chain(unix_paths(_home));
+    #[cfg(target_os = "macos")]
+    let paths = paths.chain(mac_paths(_home));
+    #[cfg(windows)]
+    let paths = paths.chain(windows_paths());
+
+    paths
+}

--- a/src/install_path.rs
+++ b/src/install_path.rs
@@ -30,13 +30,8 @@ pub fn get_install_paths() -> impl IntoIterator<Item = PathBuf> {
         .chain(default_paths)
         .flat_map(|path| path.canonicalize().ok())
         .inspect(|path| trace!(?path, "possible SDV path"))
-        .filter(|path| looks_like_game_folder(&path))
-        .inspect(|path| trace!(?path, "SDV path verified"))
-}
-
-fn looks_like_game_folder(_dir: &Path) -> bool {
-    // TODO
-    true
+        .filter(|path| path.join("Stardew Valley.dll").is_file())
+        .inspect(|path| trace!(?path, "looks like SDV path"))
 }
 
 fn get_custom_install_path(home: &Path) -> Option<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,10 @@
 )]
 
 mod ast;
+mod config;
 mod encoded_writer;
 mod events;
+mod install_path;
 mod log;
 mod parse;
 mod source;
@@ -18,5 +20,9 @@ mod startup;
 mod widgets;
 
 fn main() -> anyhow::Result<()> {
-    startup::start()
+    use crate::config::App;
+    use clap::Parser;
+
+    let config = App::parse();
+    startup::start(config)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::all, clippy::pedantic, clippy::perf)]
+#![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::module_name_repetitions,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_precision_loss,
-    clippy::cast_lossless
+    clippy::cast_lossless,
+    clippy::type_complexity
 )]
 
 mod ast;

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -153,9 +153,8 @@ fn get_source(
         }) => {
             // Start SMAPI
             let smapi_path = smapi_path
-                .or_else(|| get_install_paths().into_iter().next())
-                .context("unable to find game path")?
-                .join("StardewModdingAPI.exe");
+                .or_else(|| get_install_paths().into_iter().next().map(executable_path))
+                .context("unable to find game path")?;
             info!(smapi_path=?smapi_path.display(), "starting SMAPI");
             let process = spawn_smapi(&smapi_path, smapi_args.iter().map(AsRef::as_ref))?;
 
@@ -172,6 +171,16 @@ fn get_source(
             )
         }
     })
+}
+
+#[cfg(windows)]
+fn executable_path(install_path: impl AsRef<Path>) -> PathBuf {
+    install_path.as_ref().join("StardewModdingAPI.exe")
+}
+
+#[cfg(unix)]
+fn executable_path(install_path: impl AsRef<Path>) -> PathBuf {
+    install_path.as_ref().join("StardewValley")
 }
 
 fn spawn_smapi<'a>(

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -221,7 +221,7 @@ fn setup_tracing(log_path: Option<&Path>) -> anyhow::Result<()> {
         let log_file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
-            .open(&log_path)
+            .open(log_path)
             .with_context(|| format!("failed to open output logs file: {}", log_path.display()))?;
         let fmt_layer = tracing_subscriber::fmt::layer()
             .compact()

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,12 +1,15 @@
 use crate::{
+    config::{
+        App, AppCommand, CommandEncoding, LogCommand, RemoteCommand, RunCommand, StdinCommand,
+    },
     encoded_writer::{ByteOrder, EncodedWriter},
     events::{AppEvent, EventController},
+    install_path::get_install_paths,
     log::Log,
     source::{FollowedLogSource, LogSource, ReaderLogSource, StaticLogSource},
     widgets::{Root, RootState, State, WithLog},
 };
-use anyhow::{bail, Context};
-use clap::{command, Arg, ArgMatches, PossibleValue, ValueHint};
+use anyhow::Context;
 use crossterm::{
     event::{Event, KeyCode, KeyModifiers},
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
@@ -15,8 +18,9 @@ use crossterm::{
 use ouroboros::self_referencing;
 use reqwest::blocking::Client;
 use std::{
+    ffi::OsStr,
     io::{stdout, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Child, ChildStdin, Stdio},
 };
 use tracing::{info, trace};
@@ -26,90 +30,34 @@ use tui::{
     Terminal,
 };
 
-const LOG_ARG: &str = "log";
-const FOLLOW_ARG: &str = "follow";
-const STDIN_ARG: &str = "stdin";
-const REMOTE_ARG: &str = "remote";
-const SMAPI_ARG: &str = "execute";
-const SMAPI_ARGS_ARG: &str = "execute-args";
-const SMAPI_ENCODING_ARG: &str = "encoding";
-const OUTPUT_LOG_ARG: &str = "output-log";
-
-pub fn start() -> anyhow::Result<()> {
-    // Parse options
-    let matches = parse_args();
-
+pub fn start(config: App) -> anyhow::Result<()> {
     // Setup tracing
-    setup_tracing(&matches)?;
-
-    // Spawn SMAPI if needed
-    let smapi_child = if matches.is_present(SMAPI_ARG) {
-        Some(spawn_smapi(&matches)?)
-    } else {
-        None
-    };
+    setup_tracing(config.output_log.as_ref().map(AsRef::as_ref))?;
+    info!("starting pufferwatch");
 
     // Setup log source
-    info!("Starting SMAPI Log Parser");
-    let log_path = matches.value_of(LOG_ARG);
-    let (source, log) = get_source(&matches, log_path)?;
+    let (source, log, child_stdin) = get_source(config.command)?;
 
     // Initialize TUI
-    trace!("Initializing TUI");
+    trace!("initializing TUI");
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
 
     // Prepare alternate screen
-    trace!("Entering alternate screen");
+    trace!("entering alternate screen");
     terminal.backend_mut().execute(EnterAlternateScreen)?;
     crossterm::terminal::enable_raw_mode()?;
     terminal.hide_cursor()?;
     terminal.clear()?;
 
     // TUI event loop
-    let result = render_loop(
-        log,
-        source,
-        smapi_child
-            .and_then(|child| child.stdin)
-            .map(|stdin| create_encoded_writer(&matches, stdin)),
-        &mut terminal,
-    );
+    let result = render_loop(log, source, child_stdin, &mut terminal);
 
     // Exit alternate screen
     terminal.backend_mut().execute(LeaveAlternateScreen)?;
     terminal.show_cursor()?;
     crossterm::terminal::disable_raw_mode()?;
     result
-}
-
-fn spawn_smapi(matches: &ArgMatches) -> anyhow::Result<Child> {
-    let smapi_path = matches.value_of(SMAPI_ARG).context("missing SMAPI path")?;
-    let args = matches.values_of(SMAPI_ARGS_ARG).into_iter().flatten();
-    let mut cmd = std::process::Command::new(smapi_path);
-    let cmd = args.fold(&mut cmd, |cmd, arg| cmd.arg(arg));
-    let child = cmd
-        .stdin(Stdio::piped())
-        .stdout(Stdio::null())
-        .spawn()
-        .context("error starting SMAPI")?;
-    Ok(child)
-}
-
-fn create_encoded_writer<W>(matches: &ArgMatches, writer: W) -> EncodedWriter<W>
-where
-    W: Write,
-{
-    match matches.value_of(SMAPI_ENCODING_ARG) {
-        Some("utf8") => EncodedWriter::utf8(writer),
-        Some("utf16-le") => EncodedWriter::utf16(writer, ByteOrder::LittleEndian),
-        Some("utf16-be") => EncodedWriter::utf16(writer, ByteOrder::BigEndian),
-        #[cfg(windows)]
-        None => EncodedWriter::utf16(writer, ByteOrder::LittleEndian),
-        #[cfg(not(windows))]
-        None => EncodedWriter::utf8(writer),
-        Some(encoding) => unreachable!("unexpected encoding {encoding}"),
-    }
 }
 
 fn render_loop(
@@ -123,8 +71,8 @@ fn render_loop(
     let mut renderer = Renderer::from_log(log, smapi_stdin);
     loop {
         // Read event
-        trace!("Reading event");
-        let event = event_rx.recv().context("Error reading event")?;
+        trace!("reading event");
+        let event = event_rx.recv().context("error reading event")?;
         match event {
             // Check if quitting
             AppEvent::TermEvent(Event::Key(key_event)) => {
@@ -157,154 +105,119 @@ fn render_loop(
 }
 
 fn get_source(
-    matches: &ArgMatches,
-    log_path: Option<&str>,
-) -> Result<(Box<dyn LogSource>, Log), anyhow::Error> {
-    let stdin_flag = matches.is_present(STDIN_ARG);
-    let follow_flag = matches.is_present(FOLLOW_ARG);
-    let remote_flag = matches.is_present(REMOTE_ARG);
-    let execute_flag = matches.is_present(SMAPI_ARG);
-    let too_many_sources = [stdin_flag, follow_flag, remote_flag]
-        .into_iter()
-        .filter(|&f| f)
-        .nth(1)
-        .is_some();
-    if too_many_sources {
-        bail!(
-            "only one of --{}, --{}, --{}, --{} can be specified",
-            STDIN_ARG,
-            FOLLOW_ARG,
-            REMOTE_ARG,
-            SMAPI_ARG
-        );
+    command: AppCommand,
+) -> Result<(Box<dyn LogSource>, Log, Option<EncodedWriter<ChildStdin>>), anyhow::Error> {
+    fn resolve_log_path(log_path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+        log_path
+            .map(PathBuf::from)
+            .or_else(default_log_path)
+            .context("unable to find log path")
     }
-    let (source, log): (Box<dyn LogSource>, Log) = if stdin_flag {
-        let source = ReaderLogSource::from_stdin();
-        let log = Log::empty();
-        (Box::new(source), log)
-    } else if follow_flag || execute_flag {
-        let log_path = log_path
-            .map(PathBuf::from)
-            .or_else(default_log_path)
-            .context("unable to find log path")?;
-        let (source, log) =
-            FollowedLogSource::new(log_path).context("error creating log source")?;
-        (Box::new(source), log)
-    } else if remote_flag {
-        let log_path = log_path.context("unable to find log path")?;
-        println!("Fetching remote log...");
-        let contents = Client::new()
-            .get(log_path)
-            .send()
-            .context("error retrieving remote log")?
-            .text()
-            .context("error reading remote log")?;
-        let (source, log) =
-            StaticLogSource::from_string(contents).context("error creating log source")?;
-        (Box::new(source), log)
-    } else {
-        let log_path = log_path
-            .map(PathBuf::from)
-            .or_else(default_log_path)
-            .context("unable to find log path")?;
-        let (source, log) =
-            StaticLogSource::from_file(&log_path).context("error creating log source")?;
-        (Box::new(source), log)
-    };
-    Ok((source, log))
+
+    Ok(match command {
+        AppCommand::Log(LogCommand { log: path, follow }) => {
+            let log_path = resolve_log_path(path)?;
+            if follow {
+                let (source, log) =
+                    FollowedLogSource::new(log_path).context("error creating log source")?;
+                (Box::new(source), log, None)
+            } else {
+                let (source, log) =
+                    StaticLogSource::from_file(&log_path).context("error creating log source")?;
+                (Box::new(source), log, None)
+            }
+        }
+        AppCommand::Stdin(StdinCommand) => {
+            let source = ReaderLogSource::from_stdin();
+            let log = Log::empty();
+            (Box::new(source), log, None)
+        }
+        AppCommand::Remote(RemoteCommand { url }) => {
+            println!("Fetching remote log...");
+            info!("fetching remote log");
+            let contents = Client::new()
+                .get(url)
+                .send()
+                .context("error retrieving remote log")?
+                .text()
+                .context("error reading remote log")?;
+            let (source, log) =
+                StaticLogSource::from_string(contents).context("error creating log source")?;
+            (Box::new(source), log, None)
+        }
+        AppCommand::Run(RunCommand {
+            smapi_path,
+            smapi_args,
+            log: path,
+            encoding,
+        }) => {
+            // Start SMAPI
+            let smapi_path = smapi_path
+                .or_else(|| get_install_paths().into_iter().next())
+                .context("unable to find game path")?
+                .join("StardewModdingAPI.exe");
+            info!(smapi_path=?smapi_path.display(), "starting SMAPI");
+            let process = spawn_smapi(&smapi_path, smapi_args.iter().map(AsRef::as_ref))?;
+
+            // Follow log file
+            let log_path = resolve_log_path(path)?;
+            let (source, log) =
+                FollowedLogSource::new(log_path).context("error creating log source")?;
+            (
+                Box::new(source),
+                log,
+                process
+                    .stdin
+                    .map(|stdin| create_encoded_writer(stdin, encoding)),
+            )
+        }
+    })
 }
 
-fn parse_args() -> ArgMatches {
-    command!()
-        .arg(
-            Arg::new(LOG_ARG)
-                .help("The path to the log file.")
-                .index(1)
-                .takes_value(true)
-                .value_name("LOG PATH")
-                .value_hint(ValueHint::FilePath),
-        )
-        .arg(
-            Arg::new(OUTPUT_LOG_ARG)
-                .help("The path to output this application's logs to (not SMAPI logs). Set RUST_LOG to configure the output.")
-                .long("output-log")
-                .takes_value(true)
-                .value_name("OUTPUT LOG PATH")
-                .value_hint(ValueHint::FilePath),
-        )
-        .arg(
-            Arg::new(STDIN_ARG)
-                .help("Read from stdin instead of a log file.")
-                .long(STDIN_ARG)
-        )
-        .arg(
-            Arg::new(FOLLOW_ARG)
-                .long(FOLLOW_ARG)
-                .help("Watch the log file for changes. This is not needed with --stdin or --execute.")
-                .short('f'),
-        )
-        .arg(
-            Arg::new(REMOTE_ARG)
-                .help("Request the log from a remote source.")
-                .long(REMOTE_ARG)
-                .short('r'),
-        )
-        .arg(
-            Arg::new(SMAPI_ARG)
-                .help("Run SMAPI and track its output. The full SMAPI command must be provided (including any arguments to it).")
-                .long(SMAPI_ARG)
-                .visible_alias("exec")
-                .short('e')
-                .takes_value(true)
-                .value_name("SMAPI CMD")
-                .value_hint(ValueHint::CommandName),
-        )
-        .arg(
-            Arg::new(SMAPI_ARGS_ARG)
-                .help("The arguments to pass to the SMAPI command.")
-                .index(2)
-                .last(true)
-                .multiple_values(true)
-                .value_name("SMAPI ARGS")
-                .value_hint(ValueHint::Unknown),
-        )
-        .arg(
-            Arg::new(SMAPI_ENCODING_ARG)
-                .help("The encoding to use when sending commands to SMAPI.")
-                .long(SMAPI_ENCODING_ARG)
-                .requires(SMAPI_ARG)
-                .takes_value(true)
-                .value_name("ENCODING")
-                .possible_values([
-                    PossibleValue::new("utf8").help("UTF-8"),
-                    PossibleValue::new("utf16-le").help("UTF-16 little endian").alias("utf16"),
-                    PossibleValue::new("utf16-be").help("UTF-16 big endian"),
-                ])
-                .value_hint(ValueHint::Other),
-        )
-        .get_matches()
+fn spawn_smapi<'a>(
+    smapi_path: &'a Path,
+    args: impl IntoIterator<Item = &'a OsStr>,
+) -> anyhow::Result<Child> {
+    let mut cmd = std::process::Command::new(smapi_path);
+    let cmd = args.into_iter().fold(&mut cmd, |cmd, arg| cmd.arg(arg));
+    let child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .context("error starting SMAPI")?;
+    Ok(child)
 }
 
-fn setup_tracing(matches: &ArgMatches) -> anyhow::Result<()> {
-    if let Some(output_logs) = matches.value_of(OUTPUT_LOG_ARG) {
-        let log_path = PathBuf::from(output_logs);
+fn create_encoded_writer<W>(writer: W, encoding: CommandEncoding) -> EncodedWriter<W>
+where
+    W: Write,
+{
+    match encoding {
+        CommandEncoding::Utf8 => EncodedWriter::utf8(writer),
+        CommandEncoding::Utf16Le => EncodedWriter::utf16(writer, ByteOrder::LittleEndian),
+        CommandEncoding::Utf16Be => EncodedWriter::utf16(writer, ByteOrder::BigEndian),
+    }
+}
+
+fn setup_tracing(log_path: Option<&Path>) -> anyhow::Result<()> {
+    if let Some(log_path) = log_path {
         if let Some(parent_dir) = log_path.parent() {
             std::fs::create_dir_all(parent_dir).with_context(|| {
                 format!(
-                    "Failed to create output logs directory: {}",
+                    "failed to create output logs directory: {}",
                     parent_dir.display()
                 )
             })?;
         }
-        let output_logs = std::fs::OpenOptions::new()
+        let log_file = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
             .open(&log_path)
-            .with_context(|| format!("Failed to open output logs file: {}", log_path.display()))?;
+            .with_context(|| format!("failed to open output logs file: {}", log_path.display()))?;
         let fmt_layer = tracing_subscriber::fmt::layer()
             .compact()
             .with_ansi(false)
-            .with_writer(output_logs);
+            .with_writer(log_file);
         Registry::default()
             .with(EnvFilter::from_default_env())
             .with(fmt_layer)

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -148,7 +148,7 @@ fn get_source(
         AppCommand::Run(RunCommand {
             smapi_path,
             smapi_args,
-            log: path,
+            log,
             encoding,
         }) => {
             // Start SMAPI
@@ -159,7 +159,7 @@ fn get_source(
             let process = spawn_smapi(&smapi_path, smapi_args.iter().map(AsRef::as_ref))?;
 
             // Follow log file
-            let log_path = resolve_log_path(path)?;
+            let log_path = resolve_log_path(log)?;
             let (source, log) =
                 FollowedLogSource::new(log_path).context("error creating log source")?;
             (

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -155,7 +155,7 @@ fn get_source(
             let smapi_path = smapi_path
                 .or_else(|| get_install_paths().into_iter().next().map(executable_path))
                 .context("unable to find game path")?;
-            info!(smapi_path=?smapi_path.display(), "starting SMAPI");
+            info!(smapi_path=%smapi_path.display(), "starting SMAPI");
             let process = spawn_smapi(&smapi_path, smapi_args.iter().map(AsRef::as_ref))?;
 
             // Follow log file

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{
-        App, AppCommand, CommandEncoding, LogCommand, RemoteCommand, RunCommand, StdinCommand,
+        App, AppCommand, CommandEncoding, MonitorCommand, RemoteCommand, RunCommand, StdinCommand,
     },
     encoded_writer::{ByteOrder, EncodedWriter},
     events::{AppEvent, EventController},
@@ -115,7 +115,7 @@ fn get_source(
     }
 
     Ok(match command {
-        AppCommand::Log(LogCommand { log: path, follow }) => {
+        AppCommand::Monitor(MonitorCommand { log: path, follow }) => {
             let log_path = resolve_log_path(path)?;
             if follow {
                 let (source, log) =


### PR DESCRIPTION
Updates `pufferwatch` to the latest version of clap. This also updates the help output.

Additionally, this changes the usage. Rather than using mutually-exclusive flags like `--remote`, `--execute`, and `--stdin` to specify the log source, this PR changes pufferwatch to use subcommands instead.

![image](https://user-images.githubusercontent.com/2214247/193378473-a9404679-bb09-4be1-80da-e6619a48d8fa.png)

