### PR TITLE
Update release Ubuntu image to 20.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,7 +56,7 @@ jobs:
           - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             rust: stable
           - target: x86_64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
Updates the release image to 20.04 (from the deprecated 18.04 image).